### PR TITLE
Allow clients to define an id

### DIFF
--- a/src/money.jsx
+++ b/src/money.jsx
@@ -12,6 +12,7 @@ export default class ApiMakerInputsMoney extends React.Component {
     className: PropTypes.string,
     currenciesCollection: PropTypes.array.isRequired,
     currencyName: PropTypes.string,
+    id: PropTypes.string,
     model: PropTypes.object,
     name: PropTypes.string,
     onChange: PropTypes.func,
@@ -121,7 +122,11 @@ export default class ApiMakerInputsMoney extends React.Component {
   }
 
   inputId() {
-    return `${this.props.model.modelClassData().paramKey}_${inflection.underscore(this.props.attribute)}`
+    if (this.props.id) {
+      return this.props.id
+    } else {
+      return `${this.props.model.modelClassData().paramKey}_${inflection.underscore(this.props.attribute)}`
+    }
   }
 
   onCurrencyChanged() {

--- a/src/money.jsx
+++ b/src/money.jsx
@@ -1,4 +1,5 @@
 import formatNumber from "format-number"
+import idForComponent from "./id-for-component"
 import { MoneyFormatter } from "@kaspernj/api-maker"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
@@ -122,11 +123,7 @@ export default class ApiMakerInputsMoney extends React.Component {
   }
 
   inputId() {
-    if (this.props.id) {
-      return this.props.id
-    } else {
-      return `${this.props.model.modelClassData().paramKey}_${inflection.underscore(this.props.attribute)}`
-    }
+    return idForComponent(this)
   }
 
   onCurrencyChanged() {


### PR DESCRIPTION
This makes it possible for users of `ApiMakerInputsMoney` to specify an `id` property and have it applied to the generated `input` element.

I wanted to also add some tests for the class, but I couldn't see an easy way to do this. It doesn't look like `ApiMakerInputsMoney` is ready to be used as a standalone class.

At least I've been getting 

```js
  ● Test suite failed to run

    Cannot find module 'format-number' from 'money.jsx'

    Require stack:
      src/money.jsx
      src/index.js
      __tests__/money-test.jsx

    > 1 | import formatNumber from "format-number"
        | ^
      2 | import { MoneyFormatter } from "@kaspernj/api-maker"
      3 | import PropTypes from "prop-types"
      4 | import PropTypesExact from "prop-types-exact"

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:296:11)
      at Object.<anonymous> (src/money.jsx:1:1)
```

```js
import Adapter from "enzyme-adapter-react-16"
import Enzyme, { mount } from "enzyme"
import Money from "../src/money"
import React from "react"

Enzyme.configure({ adapter: new Adapter() })

test("sets the given id on the generated input element", () => {
  const wrapper = mount(
    <Money id="this_is_the_one" />
  )
  const component = wrapper.find("input")
  const rawInputId = component.props().id

  expect(rawInputId).toEqual("this_is_the_one")
})
```

