### PR TITLE
Verify id-generation and handling

### DIFF
--- a/__tests__/input-test.jsx
+++ b/__tests__/input-test.jsx
@@ -14,3 +14,23 @@ test("sets the given name on the generated input element", () => {
 
   expect(rawInputName).toEqual("user[name]")
 })
+
+test("sets a random id", () => {
+  const wrapper = shallow(
+    <Input />
+  )
+  const component = wrapper.find("input")
+  const rawInputId = component.props().id
+
+  expect(rawInputId).toMatch(/^[a-z0-9]{21,22}$/m)
+})
+
+test("sets the given id", () => {
+  const wrapper = shallow(
+    <Input id="mine" />
+  )
+  const component = wrapper.find("input")
+  const rawInputId = component.props().id
+
+  expect(rawInputId).toEqual("mine")
+})


### PR DESCRIPTION
This adds a few smoke tests for how `ApiMakerInput` handles receiving `id` props.