### PR TITLE
Don't set value to NaN 

### DIFF
--- a/src/money.jsx
+++ b/src/money.jsx
@@ -146,7 +146,12 @@ export default class ApiMakerInputsMoney extends React.Component {
     let whole = MoneyFormatter.stringToFloat(this.refs.whole.value)
     let cents = parseInt(whole * 100)
     let oldCents = parseInt(this.refs.input.value)
-    this.refs.input.value = cents
+
+    if (cents) {
+      this.refs.input.value = cents
+    } else{
+      this.refs.input.value = ''
+    }
 
     if (this.props.onChange && oldCents != cents)
       this.props.onChange()

--- a/src/money.jsx
+++ b/src/money.jsx
@@ -144,8 +144,8 @@ export default class ApiMakerInputsMoney extends React.Component {
 
   setCents() {
     let whole = MoneyFormatter.stringToFloat(this.refs.whole.value)
-    let cents = parseInt(whole * 100)
-    let oldCents = parseInt(this.refs.input.value)
+    let cents = parseInt(whole * 100, 10)
+    let oldCents = parseInt(this.refs.input.value, 10)
 
     if (cents) {
       this.refs.input.value = cents


### PR DESCRIPTION
When clearing the field, we'd end up parsing the empty string as an Int, which
results in `NaN`.

This has the side effect of clearing the field when a non-numeric value has been
entered. Previously the field value would be replaced with `NaN` which makes
sense to pretty much no one.